### PR TITLE
fix golang 1.11 build with libQBus_go.so error

### DIFF
--- a/cxx/examples/consumer/build.sh
+++ b/cxx/examples/consumer/build.sh
@@ -1,1 +1,1 @@
-g++ -o qbus_consumer qbus_consumer_example.cc -I../../src -L../../debug/lib -lQBus
+g++ -o qbus_consumer qbus_consumer_example.cc -I../../src -L../../lib/debug -lQBus

--- a/cxx/src/qbus_consumer_imp.cc
+++ b/cxx/src/qbus_consumer_imp.cc
@@ -67,7 +67,7 @@ bool QbusConsumerImp::Init(const std::string& log_path,
   bool rt = QbusHelper::GetQbusBrokerList(config_loader_, &broker_list_);
   INFO(__FUNCTION__ << " | Start init | qbus cluster: " << cluster_name_
       << " | config: " << config_path
-      << " | broker_lsit:" << broker_list_);
+      << " | broker_list:" << broker_list_);
 
   return (rt && InitRdKafka());
 } 

--- a/golang/examples/producer.go
+++ b/golang/examples/producer.go
@@ -14,11 +14,11 @@ func main() {
 		return
 	}
 
-	qbus_producer := qbus.NewQbusProducer()
-	if !qbus_producer.Init(os.Args[2],
-		"./producer.log",
-		"./producer.config",
-		os.Args[1]) {
+	topic := os.Args[1]
+	cluster := os.Args[2]
+
+	qbusProducer := qbus.NewQbusProducer()
+	if !qbusProducer.Init(cluster, "./producer.log", "./producer.config", topic) {
 		fmt.Printf("Failed to Init")
 		return
 	}
@@ -32,7 +32,7 @@ func main() {
 		if msg == "stop" {
 			running = false
 		} else {
-			if !qbus_producer.Produce(msg, (int64)(len(msg)), "") {
+			if !qbusProducer.Produce(msg, (int64)(len(msg)), "") {
 				fmt.Print("Failed to Produce")
 				//Retry to Produce
 			}
@@ -40,7 +40,7 @@ func main() {
 		}
 	}
 
-	qbus_producer.Uninit()
+	qbusProducer.Uninit()
 
-	qbus.DeleteQbusProducer(qbus_producer)
+	qbus.DeleteQbusProducer(qbusProducer)
 }

--- a/golang/qbus.i
+++ b/golang/qbus.i
@@ -15,3 +15,7 @@
 %include "../cxx/src/qbus_producer.h"
 %include "../cxx/src/qbus_consumer.h"
 %include "../cxx/src/qbus_consumer_callback.h"
+
+%insert(cgo_comment_typedefs) %{
+#cgo LDFLAGS:"-g -O2 -L./ -lQBus_go"
+%}


### PR DESCRIPTION
1.  cxx example LD path error.
2.  some words spelling error.
3.  swig generate go cgo code with `#cgo LDFLAGS`, in go1.11+ swig auto generate some can not found when use CGO_LDFLAGS.